### PR TITLE
fix: after an authenticated user adds a comment, the list of comments update

### DIFF
--- a/src/hooks/useFetchPost.ts
+++ b/src/hooks/useFetchPost.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { JWT_LOCALSTORAGE_KEY } from "@/contexts/auth";
 import type { Post } from "@/types/post";
 
@@ -9,36 +9,35 @@ export const useFetchPost = (postId: string) => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState("");
 
-	useEffect(() => {
-		const fetchPost = async () => {
-			setIsLoading(true);
-			setError("");
+	const fetchPost = useCallback(async () => {
+		setIsLoading(true);
+		setError("");
 
-			try {
-				const jwt = localStorage.getItem(JWT_LOCALSTORAGE_KEY) || "";
-				const res = await fetch(`${BASE_URL}/${postId}`, {
-					headers: {
-						Authorization: jwt ? `Bearer ${jwt}` : "",
-					},
-				});
+		try {
+			const jwt = localStorage.getItem(JWT_LOCALSTORAGE_KEY) || "";
+			const res = await fetch(`${BASE_URL}/${postId}`, {
+				headers: {
+					Authorization: jwt ? `Bearer ${jwt}` : "",
+				},
+			});
 
-				const json = await res.json();
-				if (!res.ok) throw new Error(json.error);
+			const json = await res.json();
+			if (!res.ok) throw new Error(json.error);
 
-				const { post } = json;
-				if (!post)
-					throw new Error("Error while getting post. Please try again.");
-				setPost(post);
-			} catch (error) {
-				setError(String(error));
-				console.error("Error when fetching post:", error);
-			} finally {
-				setIsLoading(false);
-			}
-		};
-
-		fetchPost();
+			const { post } = json;
+			if (!post) throw new Error("Error while getting post. Please try again.");
+			setPost(post);
+		} catch (error) {
+			setError(String(error));
+			console.error("Error when fetching post:", error);
+		} finally {
+			setIsLoading(false);
+		}
 	}, [postId]);
 
-	return { post, isLoading, error };
+	useEffect(() => {
+		fetchPost();
+	}, [fetchPost]);
+
+	return { post, isLoading, error, refetch: fetchPost };
 };

--- a/src/pages/Post/CommentsSection/AuthenticatedCommentInput.tsx
+++ b/src/pages/Post/CommentsSection/AuthenticatedCommentInput.tsx
@@ -9,11 +9,13 @@ import type { User } from "@/types/user";
 interface AuthenticatedCommentInputProps {
 	username: User["username"];
 	postId: Post["id"];
+	refetchComments: () => void;
 }
 
 const AuthenticatedCommentInput = ({
 	username,
 	postId,
+	refetchComments,
 }: AuthenticatedCommentInputProps) => {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [errors, setErrors] = useState<ServerSideError[] | null>(null);
@@ -63,6 +65,7 @@ const AuthenticatedCommentInput = ({
 		const isSuccessfulPost = await postComment(String(commentText));
 		if (isSuccessfulPost) {
 			form.reset();
+			refetchComments();
 		}
 	};
 

--- a/src/pages/Post/CommentsSection/AuthenticatedCommentInput.tsx
+++ b/src/pages/Post/CommentsSection/AuthenticatedCommentInput.tsx
@@ -1,6 +1,5 @@
 import { Button, Group, Stack, Text, Textarea } from "@mantine/core";
 import { useState } from "react";
-import { useNavigate } from "react-router";
 import UserAvatar from "@/components/UserAvatar";
 import { JWT_LOCALSTORAGE_KEY } from "@/contexts/auth";
 import type { ServerSideError } from "@/types/error";
@@ -18,9 +17,6 @@ const AuthenticatedCommentInput = ({
 }: AuthenticatedCommentInputProps) => {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [errors, setErrors] = useState<ServerSideError[] | null>(null);
-	const navigate = useNavigate();
-
-	const refreshPage = () => navigate(0);
 
 	const postComment = async (commentText: string): Promise<boolean> => {
 		setIsSubmitting(true);
@@ -65,7 +61,9 @@ const AuthenticatedCommentInput = ({
 		if (!commentText?.toString().trim()) return;
 
 		const isSuccessfulPost = await postComment(String(commentText));
-		if (isSuccessfulPost) refreshPage();
+		if (isSuccessfulPost) {
+			form.reset();
+		}
 	};
 
 	const hasErrors = Array.isArray(errors) && errors.length > 0;

--- a/src/pages/Post/CommentsSection/AuthenticatedCommentInput.tsx
+++ b/src/pages/Post/CommentsSection/AuthenticatedCommentInput.tsx
@@ -1,5 +1,6 @@
 import { Button, Group, Stack, Text, Textarea } from "@mantine/core";
 import { useState } from "react";
+import { useNavigate } from "react-router";
 import UserAvatar from "@/components/UserAvatar";
 import { JWT_LOCALSTORAGE_KEY } from "@/contexts/auth";
 import type { ServerSideError } from "@/types/error";
@@ -17,6 +18,9 @@ const AuthenticatedCommentInput = ({
 }: AuthenticatedCommentInputProps) => {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [errors, setErrors] = useState<ServerSideError[] | null>(null);
+	const navigate = useNavigate();
+
+	const refreshPage = () => navigate(0);
 
 	const postComment = async (commentText: string): Promise<boolean> => {
 		setIsSubmitting(true);
@@ -61,7 +65,7 @@ const AuthenticatedCommentInput = ({
 		if (!commentText?.toString().trim()) return;
 
 		const isSuccessfulPost = await postComment(String(commentText));
-		if (isSuccessfulPost) form.reset();
+		if (isSuccessfulPost) refreshPage();
 	};
 
 	const hasErrors = Array.isArray(errors) && errors.length > 0;

--- a/src/pages/Post/CommentsSection/index.tsx
+++ b/src/pages/Post/CommentsSection/index.tsx
@@ -7,12 +7,12 @@ import AuthenticatedCommentInput from "./AuthenticatedCommentInput";
 import Comment from "./Comment";
 import UnauthenticatedCommentInput from "./UnauthenticatedCommentInput";
 
-interface CommentsSectionProps {
+interface Props {
 	comments: CommentType[];
 	postId: Post["id"];
 }
 
-const CommentsSection = ({ comments, postId }: CommentsSectionProps) => {
+const CommentsSection = ({ comments, postId }: Props) => {
 	const { user } = useAuth();
 
 	return (

--- a/src/pages/Post/CommentsSection/index.tsx
+++ b/src/pages/Post/CommentsSection/index.tsx
@@ -10,9 +10,10 @@ import UnauthenticatedCommentInput from "./UnauthenticatedCommentInput";
 interface Props {
 	comments: CommentType[];
 	postId: Post["id"];
+	refetchComments: () => void;
 }
 
-const CommentsSection = ({ comments, postId }: Props) => {
+const CommentsSection = ({ comments, postId, refetchComments }: Props) => {
 	const { user } = useAuth();
 
 	return (
@@ -22,7 +23,11 @@ const CommentsSection = ({ comments, postId }: Props) => {
 			</Title>
 
 			{user ? (
-				<AuthenticatedCommentInput username={user.username} postId={postId} />
+				<AuthenticatedCommentInput
+					username={user.username}
+					postId={postId}
+					refetchComments={refetchComments}
+				/>
 			) : (
 				<UnauthenticatedCommentInput />
 			)}

--- a/src/pages/Post/index.tsx
+++ b/src/pages/Post/index.tsx
@@ -9,7 +9,7 @@ import PostHeader from "./PostHeader";
 
 const PostPage = () => {
 	const { postId } = useParams();
-	const { post, isLoading, error } = useFetchPost(String(postId));
+	const { post, isLoading, error, refetch } = useFetchPost(String(postId));
 
 	if (isLoading) return <>Loading...</>;
 	if (error || !post) return <ErrorMessageSection />;
@@ -40,7 +40,11 @@ const PostPage = () => {
 				<PostBody lede={lede} text={text} />
 			</Container>
 			<Container component="section" className={styles.section}>
-				<CommentsSection comments={comments} postId={String(postId)} />
+				<CommentsSection
+					comments={comments}
+					postId={String(postId)}
+					refetchComments={refetch}
+				/>
 			</Container>
 		</Container>
 	);


### PR DESCRIPTION
originally, I tried to just hard refresh the page using `navigate(0)` in React Router, but this is way too aggressive. Instead, I've opted for just a _re-rendering_, triggered by refetching the post details from API using the `useFetchPost` hook.

In that hook, I've now exposed the `fetchPost` method, which now gets called in the `Post` page, then passed down all the way to the `<AuthenticatedCommentInput />` component, where it is called onSubmit of the add comment form.

Unfortunately, because I've opted for Declarative mode (to keep things simpler), the re-fetch and re-render does cause loss of scroll positioning. `<ScrollRestoration />` component ([docs](https://reactrouter.com/api/components/ScrollRestoration)) is not available for Declarative mode.