### PR TITLE
feat(Header): if user is an author, then they see 'Editor' in their h…

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { Group, Paper, Title } from "@mantine/core";
+import { Divider, Group, Paper, Title } from "@mantine/core";
 import { Link } from "react-router";
 import { useAuth } from "@/contexts/auth";
 import logo from "/images/logo.png";
@@ -18,9 +18,25 @@ const Header = () => {
 					)}
 				>
 					<img src={logo} loading="eager" alt="logo" width="32" height="32" />
-					<Title order={1} fz="h3" mb={4} visibleFrom="sm">
-						Top Pressure
-					</Title>
+					<Group gap="xs">
+						<Title order={1} fz="h3" mb={4} visibleFrom="sm">
+							Top Pressure
+						</Title>
+						{user?.isAuthor && (
+							<>
+								<Divider
+									orientation="vertical"
+									size="sm"
+									h={24}
+									my="auto"
+									visibleFrom="sm"
+								/>
+								<Title order={1} fz="h3" mb={4} visibleFrom="sm">
+									Editor
+								</Title>
+							</>
+						)}
+					</Group>
 				</Group>
 
 				<HeaderRight user={user} logout={logout} />


### PR DESCRIPTION
fixes #39 

example of author header:
<img width="894" height="217" alt="image" src="https://github.com/user-attachments/assets/34d64aa2-6543-4e23-bc3d-0be8ea9fb385" />

example of non-author user header:
<img width="885" height="178" alt="image" src="https://github.com/user-attachments/assets/cec0a7c6-efb6-4152-a826-11edb08a1ad9" />

example of unauthenticated header:
<img width="873" height="112" alt="image" src="https://github.com/user-attachments/assets/5760583a-89d5-45c9-b53b-75a275530991" />
