### PR TITLE
feat: authors can delete their own post after confirmation modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"dependencies": {
 				"@mantine/core": "^9.2.1",
 				"@mantine/hooks": "^9.2.1",
+				"@mantine/modals": "^9.2.1",
 				"@tabler/icons-react": "^3.44.0",
 				"dayjs": "^1.11.20",
 				"react": "^19.2.6",
@@ -673,6 +674,18 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^19.2.0"
+			}
+		},
+		"node_modules/@mantine/modals": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-9.2.1.tgz",
+			"integrity": "sha512-YvZ85ZtMg6arFserkmmP18gJRD9ztLLT3vz8UrkwCdVwTGGr14X93hhS0UtR5X96ANXUzC8fU/S2ncQmNqw+NQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@mantine/core": "9.2.1",
+				"@mantine/hooks": "9.2.1",
+				"react": "^19.2.0",
+				"react-dom": "^19.2.0"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"@mantine/core": "^9.2.1",
 		"@mantine/hooks": "^9.2.1",
+		"@mantine/modals": "^9.2.1",
 		"@tabler/icons-react": "^3.44.0",
 		"dayjs": "^1.11.20",
 		"react": "^19.2.6",

--- a/src/components/MyPostsTable/Menu.tsx
+++ b/src/components/MyPostsTable/Menu.tsx
@@ -1,4 +1,5 @@
-import { ActionIcon, Menu as MantineMenu } from "@mantine/core";
+import { ActionIcon, Menu as MantineMenu, Text } from "@mantine/core";
+import { modals } from "@mantine/modals";
 import { IconDots } from "@tabler/icons-react";
 import { JWT_LOCALSTORAGE_KEY } from "@/contexts/auth";
 import type { AuthoredPostPreview } from "@/types/post";
@@ -37,6 +38,20 @@ const Menu = ({ post, fetchData }: Props) => {
 		console.error("Error when trying to publish post:", json.error); // TODO: need better error handling tbh
 	};
 
+	const openDeleteModal = () => {
+		modals.openConfirmModal({
+			title: "Delete post",
+			children: (
+				<Text size="sm">
+					Are you sure you want to delete this post? This action cannot be
+					undone.
+				</Text>
+			),
+			labels: { confirm: "Yes, delete", cancel: "Cancel" },
+			confirmProps: { color: "red" },
+		});
+	};
+
 	return (
 		<MantineMenu shadow="xl" width={144} position="bottom-end">
 			<MantineMenu.Target>
@@ -72,7 +87,9 @@ const Menu = ({ post, fetchData }: Props) => {
 				<MantineMenu.Divider />
 				{/* <MantineMenu.Item>Manage comments</MantineMenu.Item> */}
 				{/* <MantineMenu.Divider /> */}
-				<MantineMenu.Item c="pink">Delete post</MantineMenu.Item>
+				<MantineMenu.Item c="pink" onClick={openDeleteModal}>
+					Delete post
+				</MantineMenu.Item>
 			</MantineMenu.Dropdown>
 		</MantineMenu>
 	);

--- a/src/components/MyPostsTable/Menu.tsx
+++ b/src/components/MyPostsTable/Menu.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Menu as MantineMenu, Text } from "@mantine/core";
-import { modals } from "@mantine/modals";
+import { openDeleteModal } from "@components/modals/DeleteModal";
+import { ActionIcon, Menu as MantineMenu } from "@mantine/core";
 import { IconDots } from "@tabler/icons-react";
 import { JWT_LOCALSTORAGE_KEY } from "@/contexts/auth";
 import type { AuthoredPostPreview } from "@/types/post";
@@ -38,20 +38,6 @@ const Menu = ({ post, fetchData }: Props) => {
 		console.error("Error when trying to publish post:", json.error); // TODO: need better error handling tbh
 	};
 
-	const openDeleteModal = () => {
-		modals.openConfirmModal({
-			title: "Delete post",
-			children: (
-				<Text size="sm">
-					Are you sure you want to delete this post? This action cannot be
-					undone.
-				</Text>
-			),
-			labels: { confirm: "Yes, delete", cancel: "Cancel" },
-			confirmProps: { color: "red" },
-		});
-	};
-
 	return (
 		<MantineMenu shadow="xl" width={144} position="bottom-end">
 			<MantineMenu.Target>
@@ -87,7 +73,10 @@ const Menu = ({ post, fetchData }: Props) => {
 				<MantineMenu.Divider />
 				{/* <MantineMenu.Item>Manage comments</MantineMenu.Item> */}
 				{/* <MantineMenu.Divider /> */}
-				<MantineMenu.Item c="pink" onClick={openDeleteModal}>
+				<MantineMenu.Item
+					c="pink"
+					onClick={() => openDeleteModal({ jwt, postId: post.id, fetchData })}
+				>
 					Delete post
 				</MantineMenu.Item>
 			</MantineMenu.Dropdown>

--- a/src/components/modals/DeleteModal.tsx
+++ b/src/components/modals/DeleteModal.tsx
@@ -1,0 +1,36 @@
+import { Text } from "@mantine/core";
+import { modals } from "@mantine/modals";
+import type { AuthoredPostPreview } from "@/types/post";
+
+type Props = {
+	jwt: string;
+	postId: AuthoredPostPreview["id"];
+	fetchData: () => Promise<void>;
+};
+
+export const openDeleteModal = ({ postId, fetchData, jwt }: Props) => {
+	const deletePost = async () => {
+		const res = await fetch(
+			`${import.meta.env.VITE_API_URL}/api/v1/posts/${postId}`,
+			{
+				method: "DELETE",
+				headers: { Authorization: `Bearer ${jwt}` },
+			},
+		);
+		if (res.ok) return fetchData();
+		const json = await res.json();
+		alert(`Error when trying to delete post: ${json.error}`);
+	};
+
+	modals.openConfirmModal({
+		title: "Delete post",
+		children: (
+			<Text size="sm">
+				Are you sure you want to delete this post? This action cannot be undone.
+			</Text>
+		),
+		labels: { confirm: "Yes, delete", cancel: "Cancel" },
+		confirmProps: { color: "pink" },
+		onConfirm: deletePost,
+	});
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { RouterProvider } from "react-router";
 import { router } from "./router";
 import "@/styles/global.css";
 import "@mantine/core/styles.css";
+import { ModalsProvider } from "@mantine/modals";
 import { theme } from "@/styles/theme";
 
 const rootElement = document.getElementById("root");
@@ -15,7 +16,9 @@ if (!rootElement.innerHTML) {
 	root.render(
 		<StrictMode>
 			<MantineProvider theme={theme}>
-				<RouterProvider router={router} />
+				<ModalsProvider>
+					<RouterProvider router={router} />
+				</ModalsProvider>
 			</MantineProvider>
 		</StrictMode>,
 	);


### PR DESCRIPTION
to keep things within Mantine as much as possible, have opted to use a Mantine Modal Manager modal for this.

I tried to pass in the `onConfirm` method into the `openDeleteModal` method that gets called to trigger the appearance of the Mantine modal, however, that method needs to be an async (thus returning `Promise<void>`) because we're calling backend to delete, but Mantine wants a synchronous function (returning only `<void>`).

I haven't found out a better way to do this yet, so have just added the `deletePost` (async) method _within_ the `openDeleteModal`. this does mean we need more things in the props that get passed in - this is its shape:

```ts
// DeleteModal.tsx
type Props = {
	jwt: string;
	postId: AuthoredPostPreview["id"];
	fetchData: () => Promise<void>;
};

export const openDeleteModal = ({ postId, fetchData, jwt }: Props) => {
	const deletePost = async () => {
                // deletes the post from the database by calling DELETE endpoint on server
	};

        modals.openConfirmModal({ // mantine modals implementation });
```

preview of the modal: 
<img width="1031" height="378" alt="image" src="https://github.com/user-attachments/assets/b9d76949-fa90-4434-93a1-58bf97201635" />


fixes #67