### PR TITLE
feat(MyPostsTable): if a post does not have a title, it is displayed as such (rather than just an empty string)

### DIFF
--- a/src/components/MyPostsTable/DraftPosts.tsx
+++ b/src/components/MyPostsTable/DraftPosts.tsx
@@ -16,7 +16,11 @@ const DraftPostsTable = ({ posts, fetchData }: Props) => {
 
 		return (
 			<Table.Tr key={p.id} fz="md">
-				<Table.Td>{p.title}</Table.Td>
+				{p.title ? (
+					<Table.Td>{p.title}</Table.Td>
+				) : (
+					<Table.Td c="dimmed">Untitled</Table.Td>
+				)}
 				<Table.Td visibleFrom="xs">{lastModifiedDate}</Table.Td>
 				<Table.Td visibleFrom="sm">
 					<Group gap="xs" align="center">

--- a/src/components/MyPostsTable/DraftPosts.tsx
+++ b/src/components/MyPostsTable/DraftPosts.tsx
@@ -28,7 +28,7 @@ const DraftPostsTable = ({ posts, fetchData }: Props) => {
 						<span>{p.comments.length}</span>
 					</Group>
 				</Table.Td>
-				<Table.Td>
+				<Table.Td align="right">
 					<Menu post={p} fetchData={fetchData} />
 				</Table.Td>
 			</Table.Tr>

--- a/src/components/MyPostsTable/DraftPosts.tsx
+++ b/src/components/MyPostsTable/DraftPosts.tsx
@@ -3,6 +3,7 @@ import { IconMessage } from "@tabler/icons-react";
 import dayjs from "dayjs";
 import type { AuthoredPostPreview } from "@/types/post";
 import Menu from "./Menu";
+import styles from "./tables.module.css";
 
 interface Props {
 	posts: AuthoredPostPreview[];
@@ -22,7 +23,7 @@ const DraftPostsTable = ({ posts, fetchData }: Props) => {
 					<Table.Td c="dimmed">Untitled</Table.Td>
 				)}
 				<Table.Td visibleFrom="xs">{lastModifiedDate}</Table.Td>
-				<Table.Td visibleFrom="sm">
+				<Table.Td visibleFrom="sm" className={styles.commentsCell}>
 					<Group gap="xs" align="center">
 						<IconMessage size={18} opacity={0.6} />
 						<span>{p.comments.length}</span>
@@ -39,7 +40,9 @@ const DraftPostsTable = ({ posts, fetchData }: Props) => {
 		<Table withRowBorders={false}>
 			<Table.Thead>
 				<Table.Tr c="gray.6">
-					<Table.Th fw="normal">Title</Table.Th>
+					<Table.Th fw="normal" className={styles.titleCell}>
+						Title
+					</Table.Th>
 					<Table.Th fw="normal" visibleFrom="xs">
 						Last modified
 					</Table.Th>

--- a/src/components/MyPostsTable/PublishedPosts.tsx
+++ b/src/components/MyPostsTable/PublishedPosts.tsx
@@ -32,7 +32,7 @@ const PublishedPostsTable = ({ posts, fetchData }: Props) => {
 						<span>{p.comments.length}</span>
 					</Group>
 				</Table.Td>
-				<Table.Td>
+				<Table.Td align="right">
 					<Menu post={p} fetchData={fetchData} />
 				</Table.Td>
 			</Table.Tr>

--- a/src/components/MyPostsTable/PublishedPosts.tsx
+++ b/src/components/MyPostsTable/PublishedPosts.tsx
@@ -19,7 +19,11 @@ const PublishedPostsTable = ({ posts, fetchData }: Props) => {
 
 		return (
 			<Table.Tr key={p.id} fz="md">
-				<Table.Td>{p.title}</Table.Td>
+				{p.title ? (
+					<Table.Td>{p.title}</Table.Td>
+				) : (
+					<Table.Td c="dimmed">Untitled</Table.Td>
+				)}
 				<Table.Td visibleFrom="xs">{publishedDate}</Table.Td>
 				<Table.Td visibleFrom="sm">{lastModifiedDate}</Table.Td>
 				<Table.Td visibleFrom="md">

--- a/src/components/MyPostsTable/tables.module.css
+++ b/src/components/MyPostsTable/tables.module.css
@@ -1,0 +1,7 @@
+.titleCell {
+  min-width: 400px;
+}
+
+.commentsCell {
+  width: 8px;
+}


### PR DESCRIPTION
before:
<img width="991" height="294" alt="image" src="https://github.com/user-attachments/assets/3470524f-d0c9-451f-b83e-5c652be8bb20" />

after:
<img width="2523" height="404" alt="image" src="https://github.com/user-attachments/assets/92334e9b-e895-48f8-80a2-1be03309454e" />

however, for _published_ posts, this shouldn't even be needed ideally, because server-side should throw error if the post being published has no title: https://github.com/henrylin03/top-pressure-blog--BE/issues/41 IIUC, server-side should have full-scope of validations, and client-side only to improve UX, so will prioritise that first.

for the time being though, since I'm the only author and is provisioned manually, this is low risk